### PR TITLE
remove white spaces that brakes document styling

### DIFF
--- a/superannotate/ml/ml_funcs.py
+++ b/superannotate/ml/ml_funcs.py
@@ -116,8 +116,8 @@ def run_segmentation(project, images_list, model):
 
     :param project: project name of metadata of the project
     :type  project: str or dict
-    :param model  : The model name or metadata of the model
-    :type  model  : str or dict
+    :param model: The model name or metadata of the model
+    :type  model: str or dict
     :return: tupe of two lists, list of images on which the prediction has succeded and failed respectively
     :rtype res: tuple
     """


### PR DESCRIPTION
The documentation for the `run_segmentation` function is out of style. I don't know the exact cause, but it's probably due to the space before the colon.

![image](https://user-images.githubusercontent.com/46243939/130372554-51cfc773-cdb8-4888-a9a8-fc89ba787b3d.png)
