### PR TITLE
Fix wrong COCO bbox area in vector object-detection export

### DIFF
--- a/src/superannotate/lib/app/input_converters/converters/coco_converters/sa_vector_to_coco.py
+++ b/src/superannotate/lib/app/input_converters/converters/coco_converters/sa_vector_to_coco.py
@@ -40,7 +40,12 @@ def sa_vector_to_coco_object_detection(
             points["y2"] - points["y1"],
         )
         polygons = bbox
-        area = int((points["x2"] - points["x1"]) * points["y2"] - points["y1"])
+        # COCO bbox area is width * height. `bbox` is already
+        # (x, y, width, height), so reuse it — the previous expression
+        # `(x2 - x1) * y2 - y1` was mis-parenthesized (operator precedence made
+        # it `((x2 - x1) * y2) - y1`), producing a wrong area for every box not
+        # touching the top edge. Mirrors the keypoint path's `bbox[2] * bbox[3]`.
+        area = int(bbox[2] * bbox[3])
 
         annotation = make_annotation(
             category_id, image_info["id"], bbox, polygons, area, anno_id

--- a/tests/unit/test_coco_object_detection_area.py
+++ b/tests/unit/test_coco_object_detection_area.py
@@ -1,0 +1,39 @@
+from types import SimpleNamespace
+
+from src.superannotate.lib.app.input_converters.converters.coco_converters.sa_vector_to_coco import (  # noqa: E501
+    sa_vector_to_coco_object_detection,
+)
+
+
+def test_object_detection_area_is_width_times_height():
+    """COCO bbox `area` must be width * height.
+
+    Regression for an operator-precedence bug: `area` was computed as
+    `(x2 - x1) * y2 - y1`, i.e. `((x2 - x1) * y2) - y1`, instead of
+    `(x2 - x1) * (y2 - y1)`. For the box below (from the repo's own export
+    golden fixture) the old expression yields 9682 while the correct area is 437.
+    """
+    captured = {}
+
+    def make_annotation(category_id, image_id, bbox, segmentation, area, anno_id):
+        captured["bbox"] = bbox
+        captured["area"] = area
+        return {"id": anno_id, "bbox": bbox, "area": area}
+
+    image_commons = SimpleNamespace(image_info={"id": 1})
+    instances = [
+        {
+            "type": "bbox",
+            "classId": 5,
+            "points": {"x1": 437.16, "y1": 341.5, "x2": 465.23, "y2": 357.09},
+        }
+    ]
+
+    _, annotations = sa_vector_to_coco_object_detection(
+        make_annotation, image_commons, instances, iter([1])
+    )
+
+    assert len(annotations) == 1
+    width, height = captured["bbox"][2], captured["bbox"][3]
+    assert captured["area"] == int(width * height)
+    assert captured["area"] == 437  # not the buggy 9682


### PR DESCRIPTION
## Problem

In `sa_vector_to_coco_object_detection` (SA → COCO vector export), the annotation `area` is computed as:

```python
area = int((points["x2"] - points["x1"]) * points["y2"] - points["y1"])
```

Operator precedence parses this as `((x2 - x1) * y2) - y1`, **not** the COCO bounding-box area `(x2 - x1) * (y2 - y1)` (width × height). The missing parentheses around `(y2 - y1)` make the error term exactly `y1 * (width - 1)`, so the exported `area` is wrong for **every** bbox that isn't flush against the top edge (`y1 == 0`).

On this repo's own export golden box `{x1: 437.16, y1: 341.5, x2: 465.23, y2: 357.09}`:
- current code → `area = 9682`
- correct `w * h` → `437` (which is exactly what the shipped golden `TestVectorAnnotationImage.json` lists)

The sibling paths already do it right — instance-segmentation uses `int(_area(mask))` and keypoint uses `bbox[2] * bbox[3]` — so the intent is unambiguous.

## Fix

```diff
-        area = int((points["x2"] - points["x1"]) * points["y2"] - points["y1"])
+        area = int(bbox[2] * bbox[3])
```

`bbox` is already `(x, y, width, height)`, so this reuses the computed width/height and mirrors the keypoint path.

## Tests

Adds `tests/unit/test_coco_object_detection_area.py`, asserting `area == int(width * height)` (and `== 437` for the golden box). It **fails on the current code** (`assert 9682 == 437`) and passes with the fix.

The existing export tests never caught this because they only assert output **filename** equality (`filecmp.dircmp` `left_only`/`right_only`) and never compare file contents — so the wrong `area` values were never checked.